### PR TITLE
RUN-62 Edited hiding runes on the generator page.

### DIFF
--- a/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
@@ -19,6 +19,8 @@ private extension String {
 
 public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     
+    private static let runeItemHeight = 78
+    
     let header: UILabel = {
         let title = UILabel()
         title.textColor = UIColor(red: 0.973, green: 0.973, blue: 0.973, alpha: 1)
@@ -53,7 +55,7 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     
     let selectRunesView: SelectRuneCollectionView = {
         let layout2 = UICollectionViewFlowLayout()
-        layout2.itemSize = CGSize(width: 66, height: 78)
+        layout2.itemSize = CGSize(width: 66, height: runeItemHeight)
         layout2.minimumInteritemSpacing = 4
         layout2.minimumLineSpacing = 0
         layout2.scrollDirection = .vertical
@@ -87,6 +89,7 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
         
         RunarLayout.initBackground(for: view, with: .mainFire)
         setupViews()
+        selectRunesView.delegate = self
         configureNavigationBar()
     }
     
@@ -98,6 +101,10 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
         self.tabBarController?.tabBar.isHidden = false
+    }
+    
+    public override func viewDidLayoutSubviews() {
+        remakeConstraints()
     }
 
     private func configureNavigationBar() {
@@ -160,6 +167,22 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
             make.width.equalTo(184)
             make.height.equalTo(50)
         }
+    }
+    
+    private func remakeConstraints() {
+        let bottomConstraint = getBottomConstraint()
+        selectRunesView.snp.remakeConstraints { make in
+            make.top.equalTo(selectedRunesView.snp.bottom).offset(130)
+            make.left.equalTo(self.view.snp.left).offset(41)
+            make.right.equalTo(self.view.snp.right).offset(-41)
+            make.bottom.equalToSuperview().offset(-bottomConstraint)
+        }
+    }
+    
+    private func getBottomConstraint() -> Float{
+        let collectionViewVisibleHeight = selectRunesView.visibleSize.height
+        let rowVisibleCount = Int(collectionViewVisibleHeight) / SelectionRuneVC.runeItemHeight
+        return Float(collectionViewVisibleHeight) - Float(rowVisibleCount) * Float(SelectionRuneVC.runeItemHeight)
     }
     
     private func tapedLongGesture(runesView: SelectRuneCollectionView) {
@@ -286,5 +309,22 @@ private extension UINavigationBar {
         self.barTintColor = .navBarBackground
         self.titleTextAttributes = [NSAttributedString.Key.font: FontFamily.SFProDisplay.medium.font(size: 17),
                                     NSAttributedString.Key.foregroundColor: UIColor.white]
+    }
+}
+
+extension SelectionRuneVC: UICollectionViewDelegate {
+    
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        
+        var indexes = self.selectRunesView.indexPathsForVisibleItems
+        indexes.sort()
+        var index = indexes.first!
+        let cell = self.selectRunesView.cellForItem(at: index)!
+    
+        let position = self.selectRunesView.contentOffset.y - cell.frame.origin.y
+        if position > cell.frame.size.height / 2 {
+            index.row += 4
+        }
+        self.selectRunesView.scrollToItem(at: index, at: .top, animated: true )
     }
 }

--- a/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
@@ -171,11 +171,13 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     
     private func remakeConstraints() {
         let bottomConstraint = getBottomConstraint()
-        selectRunesView.snp.remakeConstraints { make in
-            make.top.equalTo(selectedRunesView.snp.bottom).offset(130)
-            make.left.equalTo(self.view.snp.left).offset(41)
-            make.right.equalTo(self.view.snp.right).offset(-41)
-            make.bottom.equalToSuperview().offset(-bottomConstraint)
+        if bottomConstraint > 0 {
+            selectRunesView.snp.remakeConstraints { make in
+                make.top.equalTo(selectedRunesView.snp.bottom).offset(130)
+                make.left.equalTo(self.view.snp.left).offset(41)
+                make.right.equalTo(self.view.snp.right).offset(-41)
+                make.bottom.equalToSuperview().offset(-bottomConstraint)
+            }
         }
     }
     
@@ -318,9 +320,9 @@ extension SelectionRuneVC: UICollectionViewDelegate {
         
         var indexes = self.selectRunesView.indexPathsForVisibleItems
         indexes.sort()
-        var index = indexes.first!
-        let cell = self.selectRunesView.cellForItem(at: index)!
-    
+        guard var index = indexes.first,
+              let cell = self.selectRunesView.cellForItem(at: index) else { return }
+        
         let position = self.selectRunesView.contentOffset.y - cell.frame.origin.y
         if position > cell.frame.size.height / 2 {
             index.row += 4


### PR DESCRIPTION
## Description

- Edited hiding runes when scrolling the generator. When you stop scrolling to the middle of the rune, scrolling moves to the begin of the current row. When  you stop scrolling after the middle of a rune, scrolling moves to the begin of the next row.
- Changed the bottom padding of the CollectionView so that the visible area contains an integer number of runes.

### Screenshots

These are before changing the bottom padding:

![photo_2022-10-09 20 11 15](https://user-images.githubusercontent.com/23504718/194770230-be05fc17-6767-4b19-94fa-9092997c9e34.jpeg)

<img width="344" alt="Снимок экрана 2022-10-09 в 20 20 31" src="https://user-images.githubusercontent.com/23504718/194770822-50c0bb26-eca8-4e34-b5e2-a6e03aa1d814.png">

These are after changing the bottom padding:

![photo_2022-10-09 20 11 10](https://user-images.githubusercontent.com/23504718/194770284-cbe5b5cb-a7fe-41d7-98af-87e75411d1ff.jpeg)

<img width="339" alt="Снимок экрана 2022-10-09 в 20 21 43" src="https://user-images.githubusercontent.com/23504718/194770845-6a67885c-154a-4e97-bbd2-07c1e26b77c5.png">

---

### Tests

Tested on iPhone 8, iPhone 11 Pro Max, iPhone 13 Pro Max

