### PR TITLE
Run 140 Rune names are cut 

### DIFF
--- a/Runar/Runar/Controllers/Library flow/LibraryCells/LibraryRuneCell.swift
+++ b/Runar/Runar/Controllers/Library flow/LibraryCells/LibraryRuneCell.swift
@@ -22,7 +22,7 @@ public class LibraryRuneCell: LibraryCell {
         runeTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             runeTitle.topAnchor.constraint(equalTo: topAnchor, constant: 26),
-            runeTitle.heightAnchor.constraint(equalToConstant: 24),
+            runeTitle.heightAnchor.constraint(equalToConstant: 26),
             runeTitle.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
         


### PR DESCRIPTION
Description:

- Was the problem: In the library on the rune description screen, the name of the rune was cut from the bottom.
- What is done: Changed the height constant of the rune name (24 -> 26).


These are ready features, testing is required.