### PR TITLE
Run-219 Onboarding Screen appearance logic

### DIFF
--- a/Runar/Runar/Controllers/Generator flow/RunicDrawsCollection/RunicDrawsCollectionVC.swift
+++ b/Runar/Runar/Controllers/Generator flow/RunicDrawsCollection/RunicDrawsCollectionVC.swift
@@ -86,10 +86,6 @@ class RunicDrawsCollectionVC: UICollectionViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
-        if UserDefaults.standard.bool(forKey: "hasViewedOnboardingScreen") {
-            return
-        }
-        self.navigationController?.pushViewController(OnboardingScreenVC(), animated: true)
     }
     
     @objc private func updateUI(_ notification: NSNotification) {

--- a/Runar/Runar/Controllers/Misc/FirstScreen/FirstScreenVC.swift
+++ b/Runar/Runar/Controllers/Misc/FirstScreen/FirstScreenVC.swift
@@ -211,8 +211,14 @@ final class FirstScreenVC: UIViewController {
         if checkBoxButton.isSelected {
             UserDefaults.standard.set(true, forKey: "dontShowFirstScreenAgain")
         }
-        let mainVC = MainTabBarController()
-        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootViewController(mainVC)
 
+        let mainVC = MainTabBarController()
+        let onboardingVC = OnboardingScreenVC()
+
+        if UserDefaults.standard.bool(forKey: "hasViewedOnboardingScreen") {
+            (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootViewController(mainVC)
+        } else {
+            (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootViewController(onboardingVC)
+        }
     }
 }


### PR DESCRIPTION
## Description 📝

Removed logic of opening OnboardingScreen from ViewWillAppear in RunicDrawsCollectionVC and added to FirstScreenVC when user press Next button.

---

These are ready features, testing is required.

---