### PR TITLE
Run 103 implement saving of uploaded data to core data (Generator screen)

### DIFF
--- a/Runar/Runar.xcodeproj/project.pbxproj
+++ b/Runar/Runar.xcodeproj/project.pbxproj
@@ -128,6 +128,12 @@
 		9C1F8E8228FF07480073542F /* FirstScreenVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1F8E8128FF07480073542F /* FirstScreenVC.swift */; };
 		9C3D6C5F292CDCF80027DE58 /* GenerationRuneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C5E292CDCF80027DE58 /* GenerationRuneModel.swift */; };
 		9C3D6C61292CE3770027DE58 /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C60292CE3770027DE58 /* MemoryStorage.swift */; };
+		9C3D6C7D2933BC200027DE58 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C7C2933BC200027DE58 /* CoreDataManager.swift */; };
+		9C3D6C802933BC580027DE58 /* CoreData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C7E2933BC580027DE58 /* CoreData.xcdatamodeld */; };
+		9C3D6C862933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C822933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataProperties.swift */; };
+		9C3D6C872933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C832933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataClass.swift */; };
+		9C3D6C882933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C842933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataProperties.swift */; };
+		9C3D6C892933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3D6C852933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataClass.swift */; };
 		9CAEF57829220F66006C0EF9 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAEF57729220F66006C0EF9 /* DataManager.swift */; };
 		C22B4DB42858AD2800F6245C /* String + Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22B4DB32858AD2800F6245C /* String + Extensions.swift */; };
 		C22F6E4127C3CEFF005F8B66 /* EmptyWallpaperVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22F6E4027C3CEFF005F8B66 /* EmptyWallpaperVC.swift */; };
@@ -302,6 +308,12 @@
 		9C1F8E8128FF07480073542F /* FirstScreenVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstScreenVC.swift; sourceTree = "<group>"; };
 		9C3D6C5E292CDCF80027DE58 /* GenerationRuneModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerationRuneModel.swift; sourceTree = "<group>"; };
 		9C3D6C60292CE3770027DE58 /* MemoryStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
+		9C3D6C7C2933BC200027DE58 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
+		9C3D6C7F2933BC580027DE58 /* CoreData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreData.xcdatamodel; sourceTree = "<group>"; };
+		9C3D6C822933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GeneratorRuneImageCoreDataModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		9C3D6C832933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GeneratorRuneImageCoreDataModel+CoreDataClass.swift"; sourceTree = "<group>"; };
+		9C3D6C842933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GeneratorRuneCoreDataModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		9C3D6C852933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GeneratorRuneCoreDataModel+CoreDataClass.swift"; sourceTree = "<group>"; };
 		9CAEF57729220F66006C0EF9 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		9D4C085582C7EC279C4564B8 /* Pods_Runar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C22B4DB32858AD2800F6245C /* String + Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Extensions.swift"; sourceTree = "<group>"; };
@@ -498,6 +510,7 @@
 				9C3D6C60292CE3770027DE58 /* MemoryStorage.swift */,
 				8477222D2643C9CA001C280D /* LocalStorage.swift */,
 				677C11E7289C726900CEA5D2 /* ImageFileManager.swift */,
+				9C3D6C7B2933BBD10027DE58 /* CoreData */,
 			);
 			path = Memory;
 			sourceTree = "<group>";
@@ -828,6 +841,27 @@
 				9C1F8E8128FF07480073542F /* FirstScreenVC.swift */,
 			);
 			path = FirstScreen;
+			sourceTree = "<group>";
+		};
+		9C3D6C7B2933BBD10027DE58 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				9C3D6C7C2933BC200027DE58 /* CoreDataManager.swift */,
+				9C3D6C7E2933BC580027DE58 /* CoreData.xcdatamodeld */,
+				9C3D6C812933BD0F0027DE58 /* Models */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		9C3D6C812933BD0F0027DE58 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9C3D6C832933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataClass.swift */,
+				9C3D6C822933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataProperties.swift */,
+				9C3D6C852933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataClass.swift */,
+				9C3D6C842933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataProperties.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		A2A5CAEB8FFCA1990E63BEE2 /* Pods */ = {
@@ -1263,6 +1297,7 @@
 			files = (
 				849ED285266E3251006E557A /* LibraryPoemCell.swift in Sources */,
 				849ED294266E74B9006E557A /* LibraryMenuCell.swift in Sources */,
+				9C3D6C892933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataClass.swift in Sources */,
 				C2C5584F283D9F59006B053C /* SelectedRuneCell.swift in Sources */,
 				84410672270ADA0400CD8B56 /* SelectedRuneCollectionView.swift in Sources */,
 				19D9BB0625C9874E00418CE7 /* RunesView.swift in Sources */,
@@ -1287,10 +1322,12 @@
 				9B9C266F25A2173200A4E135 /* DataBase.swift in Sources */,
 				195AEDC325B8C3A300180A49 /* AlignmentVC.swift in Sources */,
 				9BD98C972628A74200F3BBD7 /* AlertSettingsVC.swift in Sources */,
+				9C3D6C882933BD410027DE58 /* GeneratorRuneCoreDataModel+CoreDataProperties.swift in Sources */,
 				1907851425C4236000434D57 /* FirstRuneView.swift in Sources */,
 				19C0F1FC25BAF9D00027422B /* MainCellModel.swift in Sources */,
 				968939DA28D094FB00057D2A /* OnboardingSlideModel.swift in Sources */,
 				19C0F21025BAFDCB0027422B /* AlignmentInfoVM.swift in Sources */,
+				9C3D6C862933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataProperties.swift in Sources */,
 				9911206E28611139001B8FCC /* TagsCell.swift in Sources */,
 				191D32CF25B7C46A001DC210 /* Assets.swift in Sources */,
 				19D9BAD625C9765C00418CE7 /* TwoRuneView.swift in Sources */,
@@ -1321,6 +1358,7 @@
 				19C0F20A25BAFCB20027422B /* Array + Extensions.swift in Sources */,
 				84D7E60B264BAED300772EE3 /* Environment.swift in Sources */,
 				C2C5584B283D9E33006B053C /* SlectedRuneModel.swift in Sources */,
+				9C3D6C7D2933BC200027DE58 /* CoreDataManager.swift in Sources */,
 				9BD22972258AD6EF00E17E98 /* MainCell.swift in Sources */,
 				9BAEB61D25F13412004B7761 /* Affirmation.swift in Sources */,
 				9C3D6C5F292CDCF80027DE58 /* GenerationRuneModel.swift in Sources */,
@@ -1337,6 +1375,7 @@
 				9B0CB8862607922B00B2AF60 /* DescriptionView.swift in Sources */,
 				8452A5F726F3A3700069DEE5 /* GeneratorVC.swift in Sources */,
 				844106602705B43E00CD8B56 /* GenerationPopUpViewController.swift in Sources */,
+				9C3D6C872933BD410027DE58 /* GeneratorRuneImageCoreDataModel+CoreDataClass.swift in Sources */,
 				849ED28A266E33D4006E557A /* LibraryTextCell.swift in Sources */,
 				8440C514272016FD003D6B3C /* RuneData.swift in Sources */,
 				9BD98C962628A74200F3BBD7 /* LanguageCell.swift in Sources */,
@@ -1367,6 +1406,7 @@
 				9BAEB63425F18C3B004B7761 /* Interperitation+Ext.swift in Sources */,
 				84468380266392F900A0790B /* LibraryRuneCell.swift in Sources */,
 				193FFB382613319000D60171 /* CustomButton.swift in Sources */,
+				9C3D6C802933BC580027DE58 /* CoreData.xcdatamodeld in Sources */,
 				19BDC61C25C030B1000808CF /* UIControlSubscription.swift in Sources */,
 				9BD98C932628A74200F3BBD7 /* AppInfoVC.swift in Sources */,
 				9B0CB88B2607B6A000B2AF60 /* TopWithDescriptionView.swift in Sources */,
@@ -1707,6 +1747,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		9C3D6C7E2933BC580027DE58 /* CoreData.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				9C3D6C7F2933BC580027DE58 /* CoreData.xcdatamodel */,
+			);
+			currentVersion = 9C3D6C7F2933BC580027DE58 /* CoreData.xcdatamodel */;
+			path = CoreData.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 9BD228F2258A321B00E17E98 /* Project object */;
 }

--- a/Runar/Runar/Application/AppDelegate.swift
+++ b/Runar/Runar/Application/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         //NetworkMonitor
         //        if NetworkMonitor.shared.isConnected {
+        CoreDataManager.shared.applicationDocumentsDirectory()
         DataManager.shared.fetchData()
         //        } else {
         //            print("No internet")

--- a/Runar/Runar/Controllers/Generator flow/GenerationPopUpViewController.swift
+++ b/Runar/Runar/Controllers/Generator flow/GenerationPopUpViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public class GenerationPopUpViewController: UIViewController {
     
-    var runeModel: GenerationRuneModel?
+    var runeModel: GeneratorRuneCoreDataModel?
     var runeView: UIView?
     var action: Dictionary<String, Selector>.Element?
     
@@ -103,13 +103,17 @@ public class GenerationPopUpViewController: UIViewController {
         self.runeView = view
     }
     
-    public func setupModel(_ model: GenerationRuneModel?) {
+    public func setupModel(_ model: GeneratorRuneCoreDataModel?) {
         self.runeModel = model
 
-        guard let image = model?.image.image else { return }
+        guard let imageData = model?.runeImage?.image,
+              let image = UIImage(data: imageData),
+              let title = model?.title,
+              let description = model?.runeDescription else { return }
+
         self.imageView.image = image
-        self.header.attributedText = UILabel.getAttributedText(text: model!.title, lineHeight: 0.7)
-        self.desc.attributedText = UILabel.getAttributedText(text: model!.description, lineHeight: 1.12)
+        self.header.attributedText = UILabel.getAttributedText(text: title, lineHeight: 0.7)
+        self.desc.attributedText = UILabel.getAttributedText(text: description, lineHeight: 1.12)
     }
     
     public func setupPopUp(image: UIImage, header: String, description: String) {

--- a/Runar/Runar/Controllers/Generator flow/SelectRune/SelectRuneCell.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectRune/SelectRuneCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class SelectRuneCell: UICollectionViewCell {
 
-    public var model: GenerationRuneModel?
+    public var model: GeneratorRuneCoreDataModel?
     public var indexPath: IndexPath = IndexPath()
     public var isUnavailableRune: Bool = false
     
@@ -43,11 +43,13 @@ class SelectRuneCell: UICollectionViewCell {
         ])
     }
     
-    public func setRune(_ rune: GenerationRuneModel, _ indexPath: IndexPath) {
+    public func setRune(_ rune: GeneratorRuneCoreDataModel, _ indexPath: IndexPath) {
         self.model = rune
         self.indexPath = indexPath
 
-        let image = rune.image.image
+        guard let imageData = rune.runeImage?.image,
+              let image = UIImage(data: imageData) else { return }
+
         runeImage.setBackgroundImage(image, for: .normal)
     }
     

--- a/Runar/Runar/Controllers/Generator flow/SelectRune/SelectRuneCollectionView.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectRune/SelectRuneCollectionView.swift
@@ -14,15 +14,12 @@ public class SelectRuneCollectionView: UICollectionView, UICollectionViewDataSou
     private var selectDeligate: ((SelectRuneCell) -> Void)?
     internal var selectedRunesCount: Int = 0
     private var runes: [SelectRuneCell] = []
-    private lazy var persistentContainer: NSPersistentContainer = {
-        return CoreDataManager.shared.persistentContainer
-    }()
     private lazy var fetchedResultsController: NSFetchedResultsController<GeneratorRuneCoreDataModel> = {
         let fetchRequest: NSFetchRequest<GeneratorRuneCoreDataModel> = GeneratorRuneCoreDataModel.fetchRequest()
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "id", ascending: true)]
 
         let controller = NSFetchedResultsController(fetchRequest: fetchRequest,
-                                                    managedObjectContext: persistentContainer.viewContext,
+                                                    managedObjectContext: CoreDataManager.shared.persistentContainer.viewContext,
                                                     sectionNameKeyPath: nil, cacheName: nil)
         controller.delegate = self
         return controller

--- a/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
@@ -269,7 +269,8 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
             for cell in (self.selectedRunesView.visibleCells as? [SelectedRuneCell])!.sorted(by: {c1, c2 in return c1.indexPath.row < c2.indexPath.row} ) {
                 if !cell.isSelected {
                     guard let title = rune.model?.title,
-                          let image = rune.model?.image.image,
+                          let imageData = rune.model?.runeImage?.image,
+                          let image = UIImage(data: imageData),
                           let id = rune.model?.id else { return }
 
                     cell.selectRune(SelectedRuneModel(title: title,
@@ -321,7 +322,8 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
             for cell in (self.selectedRunesView.visibleCells as! [SelectedRuneCell]).sorted(by: {c1, c2 in return c1.indexPath.row < c2.indexPath.row} ) {
                 if !cell.isSelected {
                     guard let title = rune.model?.title,
-                          let image = rune.model?.image.image,
+                          let imageData = rune.model?.runeImage?.image,
+                          let image = UIImage(data: imageData),
                           let id = rune.model?.id else { return }
 
                     cell.selectRune(SelectedRuneModel(title: title,

--- a/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
+++ b/Runar/Runar/Controllers/Generator flow/SelectionRuneVC.swift
@@ -99,8 +99,7 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
         selectRunesView.delegate = self
         configureNavigationBar()
 
-        let generatorIsLoaded: Bool = DataManager.shared.generatorIsLoaded
-        guard generatorIsLoaded else { return setupActivityIndicator() }
+        guard selectRunesView.generatorSavedInCoreData else { return setupActivityIndicator() }
         setupViews()
     }
     
@@ -294,7 +293,13 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     }
 
     func update() {
-        setupViews()
+        if let cells = selectedRunesView.visibleCells as? [SelectedRuneCell] {
+            cells.forEach { selectRunesView.selectedCells.append($0) }
+        }
+
+        if !selectRunesView.generatorSavedInCoreData {
+            setupViews()
+        }
         activityIndicatorView.isHidden = true
         activityIndicatorView.stopAnimating()
         selectRunesView.setupRunes()
@@ -304,7 +309,7 @@ public class SelectionRuneVC: UIViewController, UIGestureRecognizerDelegate {
     @objc func selectRandomRunesOnTap() {
         self.selectedRunesView.deselectAll()
 
-        var maxRunes = MemoryStorage.GenerationRunes.count
+        var maxRunes = selectRunesView.fetchCountRunesFromCoreData()
 
         if SubscriptionManager.freeSubscription == true {
             maxRunes = 7

--- a/Runar/Runar/Services/Memory/CoreData/CoreData.xcdatamodeld/CoreData.xcdatamodel/contents
+++ b/Runar/Runar/Services/Memory/CoreData/CoreData.xcdatamodeld/CoreData.xcdatamodel/contents
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22A400" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="GeneratorRuneCoreDataModel" representedClassName=".GeneratorRuneCoreDataModel" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="runeDescription" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="runeImage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="GeneratorRuneImageCoreDataModel" inverseName="parent" inverseEntity="GeneratorRuneImageCoreDataModel"/>
+    </entity>
+    <entity name="GeneratorRuneImageCoreDataModel" representedClassName=".GeneratorRuneImageCoreDataModel" syncable="YES">
+        <attribute name="height" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="image" optional="YES" attributeType="Binary"/>
+        <attribute name="width" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="GeneratorRuneCoreDataModel" inverseName="runeImage" inverseEntity="GeneratorRuneCoreDataModel"/>
+    </entity>
+</model>

--- a/Runar/Runar/Services/Memory/CoreData/CoreDataManager.swift
+++ b/Runar/Runar/Services/Memory/CoreData/CoreDataManager.swift
@@ -1,0 +1,72 @@
+//
+//  CoreDataManager.swift
+//  Runar
+//
+//  Created by Alexey Poletaev on 27.11.2022.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataManager: NSObject {
+
+    static let shared = CoreDataManager()
+
+    private override init() {}
+
+    // MARK: - Core Data stack
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        let container = NSPersistentContainer(name: "CoreData")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+
+    // MARK: - Generator
+
+}
+
+extension CoreDataManager {
+    func applicationDocumentsDirectory() {
+        // The directory the application uses to store the Core Data store file. This code uses a directory named "yo.BlogReaderApp" in the application's documents directory.
+        if let url = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).last {
+            print(url.absoluteString)
+        }
+    }
+}

--- a/Runar/Runar/Services/Memory/CoreData/CoreDataManager.swift
+++ b/Runar/Runar/Services/Memory/CoreData/CoreDataManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import UIKit
 
 class CoreDataManager: NSObject {
 
@@ -53,8 +54,11 @@ extension CoreDataManager {
     private func createGeneratorRuneEntityFrom(_ node: GenerationRuneModel) {
         let context = CoreDataManager.shared.persistentContainer.viewContext
 
-        guard let generatorEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneCoreDataModel", into: context) as? GeneratorRuneCoreDataModel,
-              let generatorRuneImageEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneImageCoreDataModel", into: context) as? GeneratorRuneImageCoreDataModel else { return }
+        guard let generatorEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneCoreDataModel",
+                                                                        into: context) as? GeneratorRuneCoreDataModel,
+              let generatorRuneImageEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneImageCoreDataModel",
+                                                                                 into: context) as? GeneratorRuneImageCoreDataModel
+        else { return }
 
         generatorEntity.id = node.id
         generatorEntity.title = node.title
@@ -65,7 +69,7 @@ extension CoreDataManager {
         generatorEntity.runeImage = generatorRuneImageEntity
     }
 
-    func saveInCoreDataWith(_ nodes: [GenerationRuneModel]) {
+    func saveGeneratorInCoreDataWith(_ nodes: [GenerationRuneModel]) {
         nodes.forEach { self.createGeneratorRuneEntityFrom($0) }
 
         do {
@@ -81,9 +85,8 @@ extension CoreDataManager {
             let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: GeneratorRuneCoreDataModel.self))
             do {
                 let objects  = try context.fetch(fetchRequest) as? [NSManagedObject]
-                print("Objects count: ", objects?.count as Any)
-                _ = objects.map{$0.map{context.delete($0)}}
-                CoreDataManager.shared.saveContext()
+                objects?.forEach { context.delete($0) }
+                saveContext()
             } catch let error {
                 print("ERROR DELETING : \(error)")
             }

--- a/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneCoreDataModel+CoreDataClass.swift
+++ b/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneCoreDataModel+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  GeneratorRuneCoreDataModel+CoreDataClass.swift
+//  
+//
+//  Created by Alexey Poletaev on 27.11.2022.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class GeneratorRuneCoreDataModel: NSManagedObject {
+
+}

--- a/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneCoreDataModel+CoreDataProperties.swift
+++ b/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneCoreDataModel+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+//
+//  GeneratorRuneCoreDataModel+CoreDataProperties.swift
+//  
+//
+//  Created by Alexey Poletaev on 27.11.2022.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension GeneratorRuneCoreDataModel {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<GeneratorRuneCoreDataModel> {
+        return NSFetchRequest<GeneratorRuneCoreDataModel>(entityName: "GeneratorRuneCoreDataModel")
+    }
+
+    @NSManaged public var title: String?
+    @NSManaged public var id: String?
+    @NSManaged public var runeDescription: String?
+    @NSManaged public var runeImage: GeneratorRuneImageCoreDataModel?
+
+}

--- a/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneImageCoreDataModel+CoreDataClass.swift
+++ b/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneImageCoreDataModel+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  GeneratorRuneImageCoreDataModel+CoreDataClass.swift
+//  
+//
+//  Created by Alexey Poletaev on 27.11.2022.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class GeneratorRuneImageCoreDataModel: NSManagedObject {
+
+}

--- a/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneImageCoreDataModel+CoreDataProperties.swift
+++ b/Runar/Runar/Services/Memory/CoreData/Models/GeneratorRuneImageCoreDataModel+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+//
+//  GeneratorRuneImageCoreDataModel+CoreDataProperties.swift
+//  
+//
+//  Created by Alexey Poletaev on 27.11.2022.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension GeneratorRuneImageCoreDataModel {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<GeneratorRuneImageCoreDataModel> {
+        return NSFetchRequest<GeneratorRuneImageCoreDataModel>(entityName: "GeneratorRuneImageCoreDataModel")
+    }
+
+    @NSManaged public var width: Float
+    @NSManaged public var height: Float
+    @NSManaged public var image: Data?
+    @NSManaged public var parent: GeneratorRuneCoreDataModel?
+
+}

--- a/Runar/Runar/Services/Memory/DataManager.swift
+++ b/Runar/Runar/Services/Memory/DataManager.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 final class DataManager {
     static let shared = DataManager()
@@ -79,10 +80,61 @@ final class DataManager {
     // MARK: - Load generator
     private func loadGeneratorData() {
         // Download data from server
+        print("\n Generator data downloading \n")
         guard let runesData = RunarApi.getRunesData() else { fatalError("Runes is empty") }
+        print("\n Generator data is downloaded \n")
 
         // Enter data into the GenerationRunes memory storage
         MemoryStorage.GenerationRunes = GenerationRuneModel.create(fromData: runesData)
+        print("Memory storage count: ", MemoryStorage.GenerationRunes.count)
         generatorIsLoaded = true
+
+        clearData()
+        print("\n Generator data clear from Core Data \n")
+
+        print("\n Generator data saving in Core Data \n")
+        saveInCoreDataWith(MemoryStorage.GenerationRunes)
+        print("\n Generator data is saved in Core Data \n")
+    }
+
+    private func createGeneratorRuneEntityFrom(_ node: GenerationRuneModel) {
+        let context = CoreDataManager.shared.persistentContainer.viewContext
+
+        guard let generatorEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneCoreDataModel", into: context) as? GeneratorRuneCoreDataModel,
+              let generatorRuneImageEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneImageCoreDataModel", into: context) as? GeneratorRuneImageCoreDataModel else { return }
+
+        generatorEntity.id = node.id
+        generatorEntity.title = node.title
+        generatorEntity.runeDescription = node.description
+        generatorRuneImageEntity.image = node.image.image.pngData()
+        generatorRuneImageEntity.height = Float(node.image.height ?? 0.0)
+        generatorRuneImageEntity.width = Float(node.image.width ?? 0.0)
+        generatorEntity.runeImage = generatorRuneImageEntity
+    }
+
+    private func saveInCoreDataWith(_ nodes: [GenerationRuneModel]) {
+//        _ = nodes.map{ self.createGeneratorRuneEntityFrom($0) }
+        nodes.forEach { self.createGeneratorRuneEntityFrom($0) }
+
+        do {
+            try CoreDataManager.shared.persistentContainer.viewContext.save()
+        } catch let error {
+            print(error)
+        }
+    }
+
+    private func clearData() {
+        do {
+            let context = CoreDataManager.shared.persistentContainer.viewContext
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: GeneratorRuneCoreDataModel.self))
+            do {
+                let objects  = try context.fetch(fetchRequest) as? [NSManagedObject]
+                print("Objects count: ", objects?.count as Any)
+                _ = objects.map{$0.map{context.delete($0)}}
+                CoreDataManager.shared.saveContext()
+            } catch let error {
+                print("ERROR DELETING : \(error)")
+            }
+        }
     }
 }

--- a/Runar/Runar/Services/Memory/DataManager.swift
+++ b/Runar/Runar/Services/Memory/DataManager.swift
@@ -86,55 +86,13 @@ final class DataManager {
 
         // Enter data into the GenerationRunes memory storage
         MemoryStorage.GenerationRunes = GenerationRuneModel.create(fromData: runesData)
-        print("Memory storage count: ", MemoryStorage.GenerationRunes.count)
-        generatorIsLoaded = true
 
-        clearData()
+        CoreDataManager.shared.clearGeneratorData()
         print("\n Generator data clear from Core Data \n")
 
         print("\n Generator data saving in Core Data \n")
-        saveInCoreDataWith(MemoryStorage.GenerationRunes)
+        CoreDataManager.shared.saveInCoreDataWith(MemoryStorage.GenerationRunes)
         print("\n Generator data is saved in Core Data \n")
-    }
-
-    private func createGeneratorRuneEntityFrom(_ node: GenerationRuneModel) {
-        let context = CoreDataManager.shared.persistentContainer.viewContext
-
-        guard let generatorEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneCoreDataModel", into: context) as? GeneratorRuneCoreDataModel,
-              let generatorRuneImageEntity = NSEntityDescription.insertNewObject(forEntityName: "GeneratorRuneImageCoreDataModel", into: context) as? GeneratorRuneImageCoreDataModel else { return }
-
-        generatorEntity.id = node.id
-        generatorEntity.title = node.title
-        generatorEntity.runeDescription = node.description
-        generatorRuneImageEntity.image = node.image.image.pngData()
-        generatorRuneImageEntity.height = Float(node.image.height ?? 0.0)
-        generatorRuneImageEntity.width = Float(node.image.width ?? 0.0)
-        generatorEntity.runeImage = generatorRuneImageEntity
-    }
-
-    private func saveInCoreDataWith(_ nodes: [GenerationRuneModel]) {
-//        _ = nodes.map{ self.createGeneratorRuneEntityFrom($0) }
-        nodes.forEach { self.createGeneratorRuneEntityFrom($0) }
-
-        do {
-            try CoreDataManager.shared.persistentContainer.viewContext.save()
-        } catch let error {
-            print(error)
-        }
-    }
-
-    private func clearData() {
-        do {
-            let context = CoreDataManager.shared.persistentContainer.viewContext
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: GeneratorRuneCoreDataModel.self))
-            do {
-                let objects  = try context.fetch(fetchRequest) as? [NSManagedObject]
-                print("Objects count: ", objects?.count as Any)
-                _ = objects.map{$0.map{context.delete($0)}}
-                CoreDataManager.shared.saveContext()
-            } catch let error {
-                print("ERROR DELETING : \(error)")
-            }
-        }
+        generatorIsLoaded = true
     }
 }

--- a/Runar/Runar/Services/Memory/DataManager.swift
+++ b/Runar/Runar/Services/Memory/DataManager.swift
@@ -6,12 +6,10 @@
 //
 
 import UIKit
-import CoreData
 
 final class DataManager {
-    static let shared = DataManager()
 
-    var generatorIsLoaded: Bool = false
+    static let shared = DataManager()
     var libraryIsLoaded: Bool = false
 
     // Download data when launching the application
@@ -80,19 +78,15 @@ final class DataManager {
     // MARK: - Load generator
     private func loadGeneratorData() {
         // Download data from server
-        print("\n Generator data downloading \n")
         guard let runesData = RunarApi.getRunesData() else { fatalError("Runes is empty") }
-        print("\n Generator data is downloaded \n")
 
         // Enter data into the GenerationRunes memory storage
         MemoryStorage.GenerationRunes = GenerationRuneModel.create(fromData: runesData)
 
+        // Clear Generator Core Data
         CoreDataManager.shared.clearGeneratorData()
-        print("\n Generator data clear from Core Data \n")
 
-        print("\n Generator data saving in Core Data \n")
-        CoreDataManager.shared.saveInCoreDataWith(MemoryStorage.GenerationRunes)
-        print("\n Generator data is saved in Core Data \n")
-        generatorIsLoaded = true
+        // Create and save Generator Core Data
+        CoreDataManager.shared.saveGeneratorInCoreDataWith(MemoryStorage.GenerationRunes)
     }
 }


### PR DESCRIPTION
# Description 📝

Added CoreData to generator.

Now, when the application is first opened, the generator data is downloaded from the server while the activity indicator is displayed.
The next opening applications will display the runes already saved in CoreData. At this point, the background will be downloading data from the server and at the end of the download the data on the generator screen will be updated.

---

These are ready features, testing is required.

---
