### PR TITLE
Run 250 Removed the Subscription option from the menu

### DIFF
--- a/Runar/Runar/Controllers/Settings flow/SettingsVC.swift
+++ b/Runar/Runar/Controllers/Settings flow/SettingsVC.swift
@@ -95,7 +95,8 @@ final class SettingsVC: UIViewController {
 extension SettingsVC: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        5
+        guard SubscriptionManager.freeSubscription else { return 4 }
+        return 5
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
# Description 📝

Removed the Subscription option from the menu in case the subscription is bought. 
That means if the app is free version, the system displays the subscription option in the menu and hides if the subscription is activated.

---

These are ready features, testing is required.

---